### PR TITLE
Use window height for tabs, fixes #67

### DIFF
--- a/bugzilla.js
+++ b/bugzilla.js
@@ -66,6 +66,9 @@ function filter_self_needinfos(bugs) {
 $(function() {
   $(".badge").hide();
   $("#tabs").tabs({ heightStyle: "fill", active: 1 });
+  $(window).resize(function() {
+    $("#tabs").tabs("refresh");
+  });
   $("#stale-inner").accordion({ heightStyle: "content", collapsible: true, active: false });
 
   get_components().then(setup_components).then(() => {

--- a/index.css
+++ b/index.css
@@ -1,3 +1,6 @@
+html {
+  height: 100%;
+}
 body {
   font-family: sans-serif;
   box-sizing: border-box;


### PR DESCRIPTION
I think this fixes the issue where the tabs widget doesn't get the right size, because it is set to fill its parent, which is a body at 100% height. Setting the html to 100% height fixes the issue initially. The size doesn't update when the window size changes, so also refresh the layout of the tabs when that happens.

After:

![triage-center-fill-fix](https://user-images.githubusercontent.com/47995245/81236845-f7a5a480-8fb2-11ea-8eb0-7d7538183122.png)